### PR TITLE
Modified files to upgrade to Swift 5

### DIFF
--- a/DrawerView.xcodeproj/project.pbxproj
+++ b/DrawerView.xcodeproj/project.pbxproj
@@ -166,7 +166,7 @@
 				TargetAttributes = {
 					2BDAD3A620110F6E00AA7FC2 = {
 						CreatedOnToolsVersion = 9.2;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					2BDAD3AF20110F6E00AA7FC2 = {
@@ -378,7 +378,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -400,7 +400,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mikkovalimaki.DrawerView;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/DrawerView/DrawerView.swift
+++ b/DrawerView/DrawerView.swift
@@ -1212,7 +1212,7 @@ extension DrawerView: UIGestureRecognizerDelegate {
         if gestureRecognizer === self.panGestureRecognizer {
             if let scrollView = otherGestureRecognizer.view as? UIScrollView {
 
-                if let index = self.childScrollViews.index(where: { $0.scrollView === scrollView }) {
+                if let index = self.childScrollViews.firstIndex(where: { $0.scrollView === scrollView }) {
                     // Existing scroll view, update it.
                     let scrollInfo = self.childScrollViews[index]
                     self.childScrollViews[index].gestureRecognizers = scrollInfo.gestureRecognizers + [otherGestureRecognizer]
@@ -1287,7 +1287,7 @@ public extension BidirectionalCollection where Element == DrawerPosition {
             return nil
         }
 
-        if let index = self.index(of: position) {
+        if let index = self.firstIndex(of: position) {
             let nextIndex = self.index(index, offsetBy: offset)
             return self.indices.contains(nextIndex) ? self[nextIndex] : nil
         } else {

--- a/Example/DrawerViewExample.xcodeproj/project.pbxproj
+++ b/Example/DrawerViewExample.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 				TargetAttributes = {
 					2BF0591A205DD19C00D336DE = {
 						CreatedOnToolsVersion = 9.2;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.Maps.iOS = {
@@ -329,7 +330,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mikkovalimaki.DrawerViewExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -344,7 +345,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mikkovalimaki.DrawerViewExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Example/DrawerViewExample/AppDelegate.swift
+++ b/Example/DrawerViewExample/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/Example/DrawerViewExample/ViewController.swift
+++ b/Example/DrawerViewExample/ViewController.swift
@@ -95,7 +95,7 @@ class ViewController: UIViewController {
     private func setupDrawers() {
         let toggles = drawers
             .map { (key, value) -> UIButton in
-                let button = UIButton(type: UIButtonType.system)
+                let button = UIButton(type: UIButton.ButtonType.system)
                 button.addTarget(self, action: #selector(toggleTapped(sender:)), for: .touchUpInside)
                 button.setTitle("\(key)", for: .normal)
                 button.setTitleColor(UIColor(red: 0, green: 0.5, blue: 0.8, alpha: 0.7), for: .normal)


### PR DESCRIPTION
## Description
Used the Swift 5 conversion tool in Xcode to modify the code and upgrade to Swift 5.

## Changes
- Changed `.index` calls to `.firstIndex` (from conversion tool)
- Updated AppDelegate.swift within the Example to use new constant for `didFinishLaunchingWithOptions` (from conversion tool)
- Updated ViewController.swift within the Example to use new constant for `UIButtonType` (from conversion tool)
- Updated Swift version for project to 5.0 (from conversion tool)

## Testing
- Tested the example on an iPhone 7 running iOS 11. Verified that scrolling and switching between the different drawer states works the same way as before.

## Notes
- Let me know if there's anything I missed here!