### PR TITLE
Added a flag switching if swiping down in a scrollView [embedded in a drawer] dismisses it

### DIFF
--- a/DrawerView/DrawerView.swift
+++ b/DrawerView/DrawerView.swift
@@ -266,6 +266,7 @@ private struct ChildScrollViewInfo {
     /// Boolean indicating if the activity drawer should dismiss when you scroll down
     /// on an internal scrollView after scroll reached top of that view.
     public var childScrollViewsPanningCanDismissDrawer = true
+
     /// Boolean indicating whether the drawer is enabled. When disabled, all user
     /// interaction with the drawer is disabled. However, user interaction with the
     /// content is still possible.

--- a/DrawerView/DrawerView.swift
+++ b/DrawerView/DrawerView.swift
@@ -263,6 +263,9 @@ private struct ChildScrollViewInfo {
         return panGestureRecognizer
     }()
 
+    /// Boolean indicating if the activity drawer should dismiss when you scroll down
+    /// on an internal scrollView after scroll reached top of that view.
+    public var childScrollViewsPanningCanDismissDrawer = true
     /// Boolean indicating whether the drawer is enabled. When disabled, all user
     /// interaction with the drawer is disabled. However, user interaction with the
     /// content is still possible.
@@ -846,7 +849,7 @@ private struct ChildScrollViewInfo {
                 } else if !childReachedTheTop && !scrollingToBottom {
                     shouldScrollChildView = true
                 } else if childReachedTheTop && !scrollingToBottom {
-                    shouldScrollChildView = false
+                    shouldScrollChildView = !childScrollViewsPanningCanDismissDrawer
                 } else if !isFullyExpanded {
                     shouldScrollChildView = false
                 } else {


### PR DESCRIPTION
(after scrollView scrolled to the top)

To test behaviour: 
1. In the example project, file `ViewController`, line `140`, add: 
`drawerView.childScrollViewsPanningCanDismissDrawer = false`
2. Run the example app, expand the bottom drawer by swiping up
3. When drawer extended, drag down on the tableView embedded in the drawer

Default behaviour: 
- the whole drawer dismisses. 

Behaviour when `drawerView.childScrollViewsPanningCanDismissDrawer` set to false: 
- drawer is not dismissed by scrolling in the tableView. 