### PR TITLE
Fixes flatMap warnings (tested using xcode 12.1)

### DIFF
--- a/DrawerView/DrawerView.swift
+++ b/DrawerView/DrawerView.swift
@@ -1460,7 +1460,7 @@ fileprivate extension UIGestureRecognizer.State {
     }
 }
 
-#if !swift(>=4.2)
+#if !swift(>=4.1)
 fileprivate extension Array {
 
     // Backwards support for compactMap.


### PR DESCRIPTION
flatMap was deprecated in Swift 4.1, but we are checking for >=4.2. Fixing this silenced my warning.