### PR TITLE
Make DrawerView open

### DIFF
--- a/DrawerView/DrawerView.swift
+++ b/DrawerView/DrawerView.swift
@@ -92,7 +92,7 @@ private struct ChildScrollViewInfo {
 }
 
 
-@IBDesignable public class DrawerView: UIView {
+@IBDesignable open class DrawerView: UIView {
 
     // MARK: - Public types
 


### PR DESCRIPTION
Allow overrideing of `DrawerView` class. For more info on `public` vs `open` see: https://stackoverflow.com/a/38950955/1081325