### PR TITLE
Customize backgroundEffect blur styles for BackgroundEffectStyle.systemDefault

### DIFF
--- a/DrawerView/DrawerView.swift
+++ b/DrawerView/DrawerView.swift
@@ -174,6 +174,20 @@ private struct ChildScrollViewInfo {
             updateVisuals()
         }
     }
+    
+    /// The background blur effect style for dark mode.
+    public var darkBlurEffectStyle: UIBlurEffect.Style = .dark {
+        didSet {
+            updateVisuals()
+        }
+    }
+    
+    /// The background blur effect style for light mode.
+    public var lightBlurEffectStyle: UIBlurEffect.Style = .light {
+        didSet {
+            updateVisuals()
+        }
+    }
 
     public var borderColor: UIColor = kDefaultBorderColor {
         didSet {
@@ -1106,7 +1120,7 @@ private struct ChildScrollViewInfo {
 
     private func updateBackgroundVisuals(_ backgroundView: UIVisualEffectView) {
         backgroundView.effect = self.backgroundEffect
-            .effect(inTraitCollection: self.traitCollection)
+            .effect(inTraitCollection: self.traitCollection, darkBlurEffectStyle: darkBlurEffectStyle, lightBlurEffectStyle: lightBlurEffectStyle)
         if #available(iOS 11.0, *) {
             backgroundView.layer.cornerRadius = self.cornerRadius
             backgroundView.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
@@ -1438,7 +1452,7 @@ public extension DrawerView {
 
 extension DrawerView.BackgroundEffectStyle {
 
-    func effect(inTraitCollection traitCollection: UITraitCollection) -> UIVisualEffect? {
+    func effect(inTraitCollection traitCollection: UITraitCollection, darkBlurEffectStyle: UIBlurEffect.Style, lightBlurEffectStyle: UIBlurEffect.Style) -> UIVisualEffect? {
         switch self {
         case .none: return nil
         case let .visualEffect(effect): return effect
@@ -1450,8 +1464,8 @@ extension DrawerView.BackgroundEffectStyle {
                 darkMode = false
             }
             return darkMode
-                ? UIBlurEffect(style: .dark)
-                : UIBlurEffect(style: .light)
+                ? UIBlurEffect(style: darkBlurEffectStyle)
+                : UIBlurEffect(style: lightBlurEffectStyle)
         }
     }
 }


### PR DESCRIPTION
Hey! 
Thanks for great lib which we use in our [Sajda app](https://apps.apple.com/kz/app/sajda-prayer-times-quran/id517254891) for a long time.

> Sajda - is a super app for Muslims with more than 3 million MAU and 1.5 million DAU.

We faced with a small limitation in `DrawerView`. When I would like to set a `backgroundEffect` to `systemDefault`, for light mode I can not set it to `.extraLight` or some other values iOS provides!

So, this PR basically adds this customization for both **dark** and **light** modes, without changing the current behavior.

Regards.